### PR TITLE
assume capabilities satisfied if already own job

### DIFF
--- a/flows/builtin/helpers/capabilities.py
+++ b/flows/builtin/helpers/capabilities.py
@@ -80,7 +80,8 @@ def port_is_free(job):
 
     should_recheck = cached_port_is_free_timestamp is None or time(
     ) - cached_port_is_free_timestamp > 10
-    if cached_port_is_free is None or should_recheck:
+    if cached_port_is_free is None or \
+            cached_port_is_free is True or should_recheck:
         set_cached_port_is_free(
             not check_nonzero_exit(check_port_free_command)
         )

--- a/jobrunner/backends.py
+++ b/jobrunner/backends.py
@@ -32,5 +32,5 @@ def jobboard_backend_connection():
     job_board_backend.connect()
     with closing(job_board_backend) as conn:
         conn.unfiltered_iterjobs = conn.iterjobs
-        conn.iterjobs = jobboard_iterator(conn.iterjobs)
+        conn.iterjobs = jobboard_iterator(conn.unfiltered_iterjobs)
         yield conn

--- a/tests/unit/jobrunner/iterator/test_has_capability.py
+++ b/tests/unit/jobrunner/iterator/test_has_capability.py
@@ -8,6 +8,10 @@ from tests.testcase import TestCase
 
 class TestHasCapability(TestCase):
     def setUp(self):
+        self.already_owned = self.set_up_patch(
+            'jobrunner.iterator.already_owned'
+        )
+        self.already_owned.return_value = False
         self.job = Mock()
         to_del = (
             'does_not_exist',
@@ -54,6 +58,14 @@ class TestHasCapability(TestCase):
         self.assertFalse(ret)
 
     def test_has_capability_passes_job_as_arg_to_capability_checker(self):
+        # Will throw AssertionError if the jobboard_job kwarg is not self.job
+        has_capability('check_if_arg_is_job', jobboard_job=self.job)
+
+    def test_returns_true_if_already_owned_by_this_conductor_always(self):
+        self.already_owned.return_value = True
+
         ret = has_capability(
-            'check_if_arg_is_job', jobboard_job=self.job
+            'registered_and_evaluates_to_false', jobboard_job=self.job
         )
+
+        self.assertTrue(ret)


### PR DESCRIPTION
otherwise the conductor can't keep the lock alive if the capability
changes as a side effect of the job. example:

1. check if a port is open
2. job uses the port
3. port is no longer open
4. iterator won't find the job anymore and won't update the lock keepalive
5. another conductor will run the already running job